### PR TITLE
upstream: thumbnailer: Fix missing translation support

### DIFF
--- a/src/xplayer-video-thumbnailer.c
+++ b/src/xplayer-video-thumbnailer.c
@@ -36,6 +36,7 @@
 #include <gst/gst.h>
 #include <xplayer-pl-parser.h>
 
+#include <locale.h>
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
@@ -982,6 +983,11 @@ int main (int argc, char *argv[])
 	GdkPixbuf *pixbuf;
 	const char *input, *output;
 	ThumbApp app;
+	
+	setlocale (LC_ALL, "");
+	bindtextdomain (GETTEXT_PACKAGE, GNOMELOCALEDIR);
+	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+	textdomain (GETTEXT_PACKAGE);
 
 	context = g_option_context_new ("Thumbnail movies");
 	options = gst_init_get_option_group ();


### PR DESCRIPTION
https://github.com/GNOME/totem/commit/1a5f59710f373f48f3a7c70ee4f1a173fbc07040
https://bugzilla.gnome.org/show_bug.cgi?id=742881
