### PR TITLE
backend: Reset loaded text subtitles when closing video

### DIFF
--- a/src/backend/bacon-video-widget.c
+++ b/src/backend/bacon-video-widget.c
@@ -3801,6 +3801,8 @@ bacon_video_widget_close (BaconVideoWidget * bvw)
 
   g_clear_pointer (&bvw->priv->mrl, g_free);
   g_clear_pointer (&bvw->priv->subtitle_uri, g_free);
+  g_object_set (G_OBJECT (bvw->priv->play), "suburi", NULL, NULL);
+  g_clear_pointer (&bvw->priv->subtitle_uri, g_free);
   g_clear_pointer (&bvw->priv->user_id, g_free);
   g_clear_pointer (&bvw->priv->user_pw, g_free);
 


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=728339
